### PR TITLE
Just use bulk not streaming_bulk

### DIFF
--- a/dumbwaiter/pipeline.py
+++ b/dumbwaiter/pipeline.py
@@ -443,18 +443,7 @@ def load(fp, host='localhost', port=9200):
         client.indices.put_settings(index='menus',
                                 body='index.number_of_replicas=0')
 
-        for ok, result in helpers.streaming_bulk(client, actioner, chunk_size=4000):
-            action, result = result.popitem()
-            doc_id = '/menus/item/{0}'.format(result['_id'])
-            if not ok:
-                PIPELINE_LOGGER.error('Failed to {0} document {1}: {2}'.format(action, doc_id, result['error']))
-            else:
-                c[doc_id] += 1
-                
-            PIPELINE_LOGGER.info('{0} action succeeded for {1} documents ({2:.1%} complete)'
-                .format(action,
-                        sum(c.values()),
-                        float(sum(c.values()))/DOC_TOTAL))
+        helpers.bulk(client, actioner)
         
         # When uploads are done, refresh the index to make it available
         client.indices.put_settings(index='menus',

--- a/dumbwaiter/pipeline.py
+++ b/dumbwaiter/pipeline.py
@@ -113,7 +113,8 @@ def server(hostname, host_port):
     try:
         es = elasticsearch.Elasticsearch([{
             'host': hostname,
-            'port': host_port}])
+            'port': host_port}],
+            timeout=30)
     except Exception as e:
         PIPELINE_LOGGER.error('Check to make sure the elasticsearch server is running at the specified host/port and try again. Exiting.')
 


### PR DESCRIPTION
Back to just using elasticsearch.helpers.bulk to manage indexing. Do not use streaming_bulk directly. I am not clever. 

Performance is still not great but ES is running on a pretty small machine and this outperforms earlier runs. Goes some way toward addressing Issue #5 
